### PR TITLE
fix small ui issues

### DIFF
--- a/_sass/_gitalk.scss
+++ b/_sass/_gitalk.scss
@@ -204,6 +204,7 @@
   .markdown-body pre {
     padding: 16px;
     overflow: auto;
+    -webkit-overflow-scrolling: touch;
     font-size: 85%;
     line-height: 1.45;
     background-color: #f6f8fa;
@@ -700,6 +701,7 @@
     border-radius: 5px;
     border: 1px solid $divider-color;
     overflow: auto;
+    -webkit-overflow-scrolling: touch;
     -webkit-transition: all ease 0.25s;
     transition: all ease 0.25s;
   

--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -16,7 +16,8 @@ pre.highlight {
   border: 1px solid $oc-gray-3;
   border-radius: 3px;
   margin: 1em 0;
-  overflow: scroll;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .highlight  { background: $oc-gray-0; }

--- a/style.scss
+++ b/style.scss
@@ -180,6 +180,7 @@ dt {
   float: left;
   width: $dt-width;
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
   clear: left;
   text-align: right;
   white-space: nowrap;


### PR DESCRIPTION
1. _highlight.scss line 19: 用 auto 代替 scroll, 否则不需要滚动时也会显示滚动条
2. 为需要滚动的元素添加 -webkit-overflow-scrolling: touch; 属性，这样在手机上可以流畅惯性滚动，体验更好