### PR TITLE
Remove Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,9 +82,6 @@ gitalk:
   repo: 
   owner: 
 
-# 输入Google Analytics web tracking code
-google_analytics:
-
 
 #
 # !! 以下所有设置都不需要更改 !!

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,16 +1,1 @@
-{% if site.google_analytics %}
-	<!-- Google Analytics -->
-	<script>
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-		ga('create', '{{ site.google_analytics }}', 'auto');
-		ga('send', 'pageview', {
-		  'page': '{{ site.baseurl }}{{ page.url }}',
-		  'title': '{{ page.title | replace: "'", "\\'" }}'
-		});
-	</script>
-	<!-- End Google Analytics -->
-{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,8 +15,6 @@
         {{ content }}
       </div>
     </div>
-
-    {% include analytics.html %}
   </body>
 
   {% if page.toc==true %}


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/